### PR TITLE
Change Project Name To SMH-App Updates

### DIFF
--- a/apps/resources/urls.py
+++ b/apps/resources/urls.py
@@ -1,0 +1,7 @@
+from django.urls import include, path
+
+from .views import resources_page
+
+urlpatterns = [
+    path('', resources_page, name='resources'),
+]


### PR DESCRIPTION
In #7 we changed the project name from `smh-organization` to `smh-app`, but forgot to add the `resources/urls.py` file to the repo. The file is included in this pull request.

TODO: we should decide on either `smh_app` or `smh-app`. Currently, the code expects `smh-app`, but the repo name is `smh_app`, which makes the the setup slightly incorrect.