### PR TITLE
More Changes To Project Name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,8 @@ Getting Started
 
 First clone the repository from Github and switch to the new directory::
 
-    $ git clone git@github.com:TransparentHealth/smh-app
-    $ cd smh-app
+    $ git clone git@github.com:TransparentHealth/smh_app
+    $ cd smh_app
 
 To setup your local environment you can use the quickstart make target `setup`, which will
 install Python (via pip) into a virtualenv named "smh_app",


### PR DESCRIPTION
It looks like #8 was merged in without finishing the TODO, so this pull request finishes that TODO: `smh-app` has been renamed to be `smh_app` in the README.