### PR TITLE
Use `env` from getenv in settings.py

### DIFF
--- a/smh_app/settings.py
+++ b/smh_app/settings.py
@@ -201,13 +201,13 @@ SOCIAL_AUTH_SHAREMYHEALTH_PIPELINE = (
 # backend must come after 'SOCIAL_AUTH_' in these settings, in order for
 # social-auth-app-django to recognize it. For example, for VMI, we define
 # settings that begin with 'SOCIAL_AUTH_VMI_'.
-SOCIAL_AUTH_NAME = os.environ.get('VMI_OAUTH_NAME', 'vmi')
-SOCIAL_AUTH_VMI_HOST = os.environ.get('VMI_OAUTH_HOST')
-SOCIAL_AUTH_VMI_KEY = os.environ.get('VMI_OAUTH_KEY')
-SOCIAL_AUTH_VMI_SECRET = os.environ.get('VMI_OAUTH_SECRET')
-SOCIAL_AUTH_SHAREMYHEALTH_HOST = os.environ.get('SMH_OAUTH_HOST')
-SOCIAL_AUTH_SHAREMYHEALTH_KEY = os.environ.get('SMH_OAUTH_KEY')
-SOCIAL_AUTH_SHAREMYHEALTH_SECRET = os.environ.get('SMH_OAUTH_SECRET')
+SOCIAL_AUTH_NAME = env('VMI_OAUTH_NAME', 'vmi')
+SOCIAL_AUTH_VMI_HOST = env('VMI_OAUTH_HOST')
+SOCIAL_AUTH_VMI_KEY = env('VMI_OAUTH_KEY')
+SOCIAL_AUTH_VMI_SECRET = env('VMI_OAUTH_SECRET')
+SOCIAL_AUTH_SHAREMYHEALTH_HOST = env('SMH_OAUTH_HOST')
+SOCIAL_AUTH_SHAREMYHEALTH_KEY = env('SMH_OAUTH_KEY')
+SOCIAL_AUTH_SHAREMYHEALTH_SECRET = env('SMH_OAUTH_SECRET')
 
 
 # Static files (CSS, JavaScript, Images)

--- a/smh_app/urls.py
+++ b/smh_app/urls.py
@@ -34,6 +34,6 @@ urlpatterns = [
     path(r'member/', include('apps.member.urls')),
     path(r'lockbox/', include('apps.lockbox.urls')),
     path(r'affiliations/', include('apps.affiliations.urls')),
-    path('social_auth/', include('social_django.urls', namespace='social')),
+    path('social-auth/', include('social_django.urls', namespace='social')),
     path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
This reimplements work done in a94e8ff and lost in a merge conflict.

Also included is a change in social auth url from social_auth to
social-auth so that it matches the configuration of other systems in the
cdex echosystem.