### PR TITLE
Minor updates During Member Creation

### DIFF
--- a/apps/org/views.py
+++ b/apps/org/views.py
@@ -1,5 +1,6 @@
 import json
 import requests
+import re
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -190,9 +191,10 @@ class OrgCreateMemberView(LoginRequiredMixin, OrgCreateMemberMixin, FormView):
             'password': 'abcde12345',
             'birthdate': '2000-01-01',
             'nickname': self.request.POST.get('first_name'),
-            'email': 'test_{}_{}@example.com'.format(
-                self.request.POST.get('first_name'),
-                self.request.POST.get('last_name'),
+            'email': '{}_{}_{}@example.com'.format(
+                "".join(re.findall("[a-zA-Z]+", self.request.POST.get('username'))),
+                "".join(re.findall("[a-zA-Z]+", self.request.POST.get('first_name'))),
+                "".join(re.findall("[a-zA-Z]+", self.request.POST.get('last_name'))),
             ),
         }
         # POST the data to VMI


### PR DESCRIPTION
This pull request makes the following updates during the new member creation process:

 - the temporary email created during the first step now only includes characters that are valid for an email address (so the user doesn’t get an `'Enter a valid email address.'` error on a step that doesn’t have an email field).