### PR TITLE
[smh-app-66] make fields optional

### DIFF
--- a/apps/org/forms.py
+++ b/apps/org/forms.py
@@ -42,9 +42,14 @@ class UpdateNewMemberAtOrgBasicInfoForm(Form):
     """
     birthdate = DateField(required=True)
     gender = ChoiceField(choices=GENDER_CHOICES, required=False)
-    nickname = CharField(required=True)
-    email = EmailField(required=True)
+    nickname = CharField(required=False)
+    email = EmailField(required=False)
 
+    def clean(self):
+        super().clean()
+        # even though it's a date field, keep it as a string for json.dumps
+        if 'birthdate' in self.cleaned_data:
+            self.cleaned_data['birthdate'] = str(self.cleaned_data['birthdate'])
 
 class VerifyMemberIdentityForm(Form):
     """
@@ -53,9 +58,15 @@ class VerifyMemberIdentityForm(Form):
     This form is used in the third step of the process for an Organization user
     to help a person become a Member at that Organization.
     """
-    classification = ChoiceField(choices=IDENTITY_VERIFICATION_CLASSIFICATIONS, required=True)
-    description = CharField(required=True)
-    expiration_date = DateField(required=True)
+    classification = ChoiceField(choices=IDENTITY_VERIFICATION_CLASSIFICATIONS, required=False)
+    description = CharField(required=False)
+    expiration_date = DateField(required=False)
+
+    def clean(self):
+        super().clean()
+        # even though it's a date field, keep it as a string for json.dumps
+        if 'expiration_date' in self.cleaned_data:
+            self.cleaned_data['expiration_date'] = str(self.cleaned_data['expiration_date'])
 
 
 class UpdateNewMemberAtOrgAdditionalInfoForm(Form):

--- a/apps/org/forms.py
+++ b/apps/org/forms.py
@@ -51,6 +51,7 @@ class UpdateNewMemberAtOrgBasicInfoForm(Form):
         if 'birthdate' in self.cleaned_data:
             self.cleaned_data['birthdate'] = str(self.cleaned_data['birthdate'])
 
+
 class VerifyMemberIdentityForm(Form):
     """
     A form for verifying a Member's identity.

--- a/apps/org/tests/test_views.py
+++ b/apps/org/tests/test_views.py
@@ -589,7 +589,7 @@ class OrgCreateMemberBasicInfoViewTestCase(SMHAppTestMixin, TestCase):
             self.assertEqual(
                 response.context['form'].errors,
                 {
-                    # 'nickname': ['This field is required.'], 
+                    # 'nickname': ['This field is required.'],
                     # 'email': ['This field is required.']
                 }
             )

--- a/apps/org/tests/test_views.py
+++ b/apps/org/tests/test_views.py
@@ -573,8 +573,8 @@ class OrgCreateMemberBasicInfoViewTestCase(SMHAppTestMixin, TestCase):
                 response.context['form'].errors,
                 {
                     'birthdate': ['This field is required.'],
-                    'nickname': ['This field is required.'],
-                    'email': ['This field is required.'],
+                    # 'nickname': ['This field is required.'],
+                    # 'email': ['This field is required.'],
                 }
             )
             # The self.member was not updated
@@ -588,7 +588,10 @@ class OrgCreateMemberBasicInfoViewTestCase(SMHAppTestMixin, TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(
                 response.context['form'].errors,
-                {'nickname': ['This field is required.'], 'email': ['This field is required.']}
+                {
+                    # 'nickname': ['This field is required.'], 
+                    # 'email': ['This field is required.']
+                }
             )
             # The self.member was not updated
             self.member.user.refresh_from_db()
@@ -872,9 +875,9 @@ class OrgCreateMemberVerifyIdentityTestCase(SMHAppTestMixin, TestCase):
             self.assertEqual(
                 response.context['form'].errors,
                 {
-                    'classification': ['This field is required.'],
-                    'description': ['This field is required.'],
-                    'expiration_date': ['This field is required.'],
+                    # 'classification': ['This field is required.'],
+                    # 'description': ['This field is required.'],
+                    # 'expiration_date': ['This field is required.'],
                 }
             )
             # No requests were made to VMI
@@ -892,7 +895,9 @@ class OrgCreateMemberVerifyIdentityTestCase(SMHAppTestMixin, TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(
                 response.context['form'].errors,
-                {'classification': ['This field is required.']}
+                {
+                    # 'classification': ['This field is required.']
+                }
             )
             # No requests were made to VMI
             self.assertEqual(self.response_id_assurance_list.call['count'], 0)

--- a/apps/org/views.py
+++ b/apps/org/views.py
@@ -303,7 +303,7 @@ class OrgCreateMemberBasicInfoView(LoginRequiredMixin, OrgCreateMemberMixin, For
         # 3.) Make a request to VMI to update the new user
         # The data to be PUT to VMI
         # (at this point we know the form itself is valid; only put fields that are non-empty)
-        data = {k: v for k, v in form.cleaned_data.items() if bool(v)==True}
+        data = {k: v for k, v in form.cleaned_data.items() if bool(v) is True}
 
         # PUT the data to VMI
         url = '{}/api/v1/user/{}/'.format(settings.SOCIAL_AUTH_VMI_HOST, member_social_auth.uid)
@@ -356,8 +356,8 @@ class OrgCreateMemberVerifyIdentityView(LoginRequiredMixin, OrgCreateMemberMixin
          5.) redirect the user to the next step in the Member-creation process
         """
         # Only post the form_data if it's non-empty -- otherwise, we can skip this step
-        form_data = {k: v for k, v in form.cleaned_data.items() if bool(v)==True}
-        if bool(form_data)==True:
+        form_data = {k: v for k, v in form.cleaned_data.items() if bool(v) is True}
+        if bool(form_data) is True:
             # 1.) Verify that the request.user has a UserSocialAuth object for VMI
             request_user_social_auth = self.request.user.social_auth.filter(
                 provider=settings.SOCIAL_AUTH_NAME

--- a/apps/org/views.py
+++ b/apps/org/views.py
@@ -302,12 +302,9 @@ class OrgCreateMemberBasicInfoView(LoginRequiredMixin, OrgCreateMemberMixin, For
 
         # 3.) Make a request to VMI to update the new user
         # The data to be PUT to VMI
-        data = {
-            'gender': self.request.POST.get('gender'),
-            'birthdate': self.request.POST.get('birthdate'),
-            'nickname': self.request.POST.get('nickname'),
-            'email': self.request.POST.get('email'),
-        }
+        # (at this point we know the form itself is valid; only put fields that are non-empty)
+        data = {k: v for k, v in form.cleaned_data.items() if bool(v)==True}
+
         # PUT the data to VMI
         url = '{}/api/v1/user/{}/'.format(settings.SOCIAL_AUTH_VMI_HOST, member_social_auth.uid)
         headers = {'Authorization': "Bearer {}".format(request_user_social_auth.access_token)}
@@ -358,53 +355,54 @@ class OrgCreateMemberVerifyIdentityView(LoginRequiredMixin, OrgCreateMemberMixin
          4.) make a request to VMI to update the user's identity assurance
          5.) redirect the user to the next step in the Member-creation process
         """
-        # 1.) Verify that the request.user has a UserSocialAuth object for VMI
-        request_user_social_auth = self.request.user.social_auth.filter(
-            provider=settings.SOCIAL_AUTH_NAME
-        ).first()
-        # If the request.user does not have a UserSocialAuth for VMI, then
-        # return the error to the user.
-        if not request_user_social_auth:
-            self.errors = {
-                'user': 'User has no association with {}'.format(settings.SOCIAL_AUTH_NAME)
-            }
-            return self.render_to_response(self.get_context_data())
+        # Only post the form_data if it's non-empty -- otherwise, we can skip this step
+        form_data = {k: v for k, v in form.cleaned_data.items() if bool(v)==True}
+        if bool(form_data)==True:
+            # 1.) Verify that the request.user has a UserSocialAuth object for VMI
+            request_user_social_auth = self.request.user.social_auth.filter(
+                provider=settings.SOCIAL_AUTH_NAME
+            ).first()
+            # If the request.user does not have a UserSocialAuth for VMI, then
+            # return the error to the user.
+            if not request_user_social_auth:
+                self.errors = {
+                    'user': 'User has no association with {}'.format(settings.SOCIAL_AUTH_NAME)
+                }
+                return self.render_to_response(self.get_context_data())
 
-        # 2.) Verify that the Member has a UserSocialAuth object for VMI
-        member_social_auth = self.member.user.social_auth.filter(
-            provider=settings.SOCIAL_AUTH_NAME
-        ).first()
-        # If the Member does not have a UserSocialAuth for VMI, return an error to the user.
-        if not member_social_auth:
-            self.errors = {
-                'member': 'Member has no association with {}'.format(settings.SOCIAL_AUTH_NAME)
-            }
-            return self.render_to_response(self.get_context_data())
+            # 2.) Verify that the Member has a UserSocialAuth object for VMI
+            member_social_auth = self.member.user.social_auth.filter(
+                provider=settings.SOCIAL_AUTH_NAME
+            ).first()
+            # If the Member does not have a UserSocialAuth for VMI, return an error to the user.
+            if not member_social_auth:
+                self.errors = {
+                    'member': 'Member has no association with {}'.format(settings.SOCIAL_AUTH_NAME)
+                }
+                return self.render_to_response(self.get_context_data())
 
-        headers = {'Authorization': "Bearer {}".format(request_user_social_auth.access_token)}
-        # 4.) Make a request to VMI to update the user's identity assurance
-        url = '{}/api/v1/user/{}/id-assurance/'.format(
-            settings.SOCIAL_AUTH_VMI_HOST,
-            member_social_auth.uid,
-        )
-        data = {
-            'subject_user': member_social_auth.uid,
-            'classification': self.request.POST.get('classification'),
-            'description': self.request.POST.get('description'),
-            'exp': self.request.POST.get('expiration_date'),
-        }
-        # POST the data to the VMI endpoint for identity verification
-        response = requests.post(url=url, json=data, headers=headers)
-
-        if response.status_code == 201:
-            # Redirect the user to the next step in the Member-creation process
-            return HttpResponseRedirect(
-                self.get_success_url(self.organization.slug, self.member.user.username)
+            headers = {'Authorization': "Bearer {}".format(request_user_social_auth.access_token)}
+            # 4.) Make a request to VMI to update the user's identity assurance
+            url = '{}/api/v1/user/{}/id-assurance/'.format(
+                settings.SOCIAL_AUTH_VMI_HOST,
+                member_social_auth.uid,
             )
-        else:
-            # The request to update a user in VMI did not succeed, so show errors to the user.
-            self.errors = json.loads(response.content)
-            return self.render_to_response(self.get_context_data())
+            data = {
+                'subject_user': member_social_auth.uid,
+                **form_data,
+            }
+            # POST the data to the VMI endpoint for identity verification
+            response = requests.post(url=url, json=data, headers=headers)
+
+            if response.status_code != 201:
+                # The request to update a user in VMI did not succeed, so show errors to the user.
+                self.errors = json.loads(response.content)
+                return self.render_to_response(self.get_context_data())
+
+        # Redirect the user to the next step in the Member-creation process
+        return HttpResponseRedirect(
+            self.get_success_url(self.organization.slug, self.member.user.username)
+        )
 
 
 class OrgCreateMemberAdditionalInfoInfoView(LoginRequiredMixin, OrgCreateMemberMixin, FormView):


### PR DESCRIPTION
Several fields should not be required in the create member workflow:

* UpdateNewMemberAtOrgBasicInfoForm:
  * nickname
  * email
* VerifyMemberIdentityForm
  * classification
  * description
  * expiration_date

In addition to setting `require=False`, the VMI app doesn't like empty fields, so we only post values that are non-empty. 

Tests adjusted to accommodate the new optional nature of these fields.