### PR TITLE
make Verify Identity fields optional

### DIFF
--- a/apps/org/forms.py
+++ b/apps/org/forms.py
@@ -61,13 +61,13 @@ class VerifyMemberIdentityForm(Form):
     """
     classification = ChoiceField(choices=IDENTITY_VERIFICATION_CLASSIFICATIONS, required=False)
     description = CharField(required=False)
-    expiration_date = DateField(required=False)
+    exp = DateField(required=False, label='Expiration Date')
 
     def clean(self):
         super().clean()
         # even though it's a date field, keep it as a string for json.dumps
-        if 'expiration_date' in self.cleaned_data:
-            self.cleaned_data['expiration_date'] = str(self.cleaned_data['expiration_date'])
+        if self.cleaned_data.get('exp'):
+            self.cleaned_data['exp'] = str(self.cleaned_data['exp'])
 
 
 class UpdateNewMemberAtOrgAdditionalInfoForm(Form):

--- a/apps/org/templates/org/member_additional_info.html
+++ b/apps/org/templates/org/member_additional_info.html
@@ -10,7 +10,7 @@
 {% if errors %}
     <div class="errors">
         {% for key, error in errors.items %}
-            <div>{{ key.title }}: {{ error.0 }}</div>
+            <div>{{ key.title }}: {% for err in error %}{{ err }}{% endfor %}</div>
         {% endfor %}
     </div>
 {% endif %}

--- a/apps/org/templates/org/member_basic_info.html
+++ b/apps/org/templates/org/member_basic_info.html
@@ -10,7 +10,7 @@
 {% if errors %}
     <div class="errors">
         {% for key, error in errors.items %}
-            <div>{{ key.title }}: {{ error.0 }}</div>
+            <div>{{ key.title }}: {% for err in error %}{{ err }}{% endfor %}</div>
         {% endfor %}
     </div>
 {% endif %}

--- a/apps/org/templates/org/member_complete.html
+++ b/apps/org/templates/org/member_complete.html
@@ -10,7 +10,7 @@
 {% if errors %}
     <div class="errors">
         {% for key, error in errors.items %}
-            <div>{{ key.title }}: {{ error.0 }}</div>
+            <div>{{ key.title }}: {% for err in error %}{{ err }}{% endfor %}</div>
         {% endfor %}
     </div>
 {% endif %}

--- a/apps/org/templates/org/member_verify_identity.html
+++ b/apps/org/templates/org/member_verify_identity.html
@@ -10,7 +10,7 @@
 {% if errors %}
     <div class="errors">
         {% for key, error in errors.items %}
-            <div>{{ key.title }}: {{ error.0 }}</div>
+            <div>{{ key.title }}: {% for err in error %}{{ err }}{% endfor %}</div>
         {% endfor %}
     </div>
 {% endif %}

--- a/apps/org/templates/org/org_create_member.html
+++ b/apps/org/templates/org/org_create_member.html
@@ -10,7 +10,7 @@
 {% if errors %}
     <div class="errors">
         {% for key, error in errors.items %}
-            <div>{{ key.title }}: {{ error.0 }}</div>
+            <div>{{ key.title }}: {% for err in error %}{{ err }}{% endfor %}</div>
         {% endfor %}
     </div>
 {% endif %}

--- a/apps/org/templates/org/organization.html
+++ b/apps/org/templates/org/organization.html
@@ -1,13 +1,20 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h2>{% if form.instance.id %}{{ form.instance }}{% else %}New Organization{% endif %}</h2>
-
-<form method="post">
-  {% csrf_token %}
-  {{ form.as_p }}
-  <button type="submit">Submit</button>
-</form>
-
-
+<div class="container mt-5">
+    <div class="row">
+        <div class="col">
+            <h2>{% if form.instance.id %}{{ form.instance }}{% else %}New Organization{% endif %}</h2>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
+            <form method="post">
+              {% csrf_token %}
+              {{ form.as_p }}
+              <button type="submit">Submit</button>
+            </form>
+        </div>
+    </div>
+</div>
 {% endblock content %}

--- a/apps/org/views.py
+++ b/apps/org/views.py
@@ -392,7 +392,6 @@ class OrgCreateMemberVerifyIdentityView(LoginRequiredMixin, OrgCreateMemberMixin
             )
 
             data = {
-                'exp': form_data['expiration_date'],
                 'subject_user': member_social_auth.uid,
                 **form_data,
             }


### PR DESCRIPTION
This is round 2 on making the fields optional on the Verify Identity modal in org create member.