### PR TITLE
Member edit orgs

### DIFF
--- a/apps/member/forms.py
+++ b/apps/member/forms.py
@@ -1,0 +1,9 @@
+
+from django import forms
+from apps.org.models import ResourceRequest
+
+class ResourceRequestForm(forms.ModelForm):
+    class Meta:
+        model = ResourceRequest
+        fields = '__all__'
+

--- a/apps/member/forms.py
+++ b/apps/member/forms.py
@@ -1,9 +1,9 @@
-
 from django import forms
 from apps.org.models import ResourceRequest
 
+
 class ResourceRequestForm(forms.ModelForm):
+
     class Meta:
         model = ResourceRequest
         fields = '__all__'
-

--- a/apps/member/templates/member/dashboard.html
+++ b/apps/member/templates/member/dashboard.html
@@ -11,7 +11,11 @@
             <div class="tile undefined">
                 <div class="alert-item">
                     <!-- TODO: add image to organization model perhaps. access resource_request.organization.picture?? -->
+                    {% if resource_request.organization.picture_url %}
+                    <img src="{{ organization.picture_url }}" alt="" class="alert-item__image"/>
+                    {% else %}
                     <img src="{% static '/images/icons/organization_default.png' %}" alt="" class="alert-item__image">
+                    {% endif %}
                     <div class="alert-item-content">
                         <div class="alert-item__text">
                             <p>{{ resource_request.notification_text }}</p>
@@ -45,7 +49,11 @@
         {% if organizations %}
           {% for organization in organizations %}
             <div class="organization-item">
+              {% if organization.picture_url %}
+              <img src="{{ organization.picture_url }}" alt="" class="alert-item__image">
+              {% else %}
               <img src="{% static '/images/icons/organization_default.png' %}" alt="" class="alert-item__image">
+              {% endif %}
               <div class="title">{{ organization }}</div>
             </div>
           {% endfor %}

--- a/apps/member/templates/member/dashboard.html
+++ b/apps/member/templates/member/dashboard.html
@@ -40,7 +40,7 @@
           </div>
         {% endif %}
       </div>
-      <h2 class="mb-3 pb-3">Organizations <a href="#">Edit</a></h2>
+      <h2 class="mb-3 pb-3">Organizations <a href="{% url 'member:organizations' pk=request.user.member.pk %}">Edit</a></h2>
       <div class="organization-list">
         {% if organizations %}
           {% for organization in organizations %}
@@ -67,8 +67,8 @@
                     {% else %}
                       <img src="{% static '/images/icons/avatar_default.png' %}" alt="Account menu icon", class="alert-item__image">
                     {% endif %}
-        
-      
+
+
         <div class="profile-text">
           <div class="title">{{ request.user.first_name }} {{ request.user.last_name }}</div>
           <div class="age">{{ request.user.member }}</div>

--- a/apps/member/templates/member/organization_request_modal.html
+++ b/apps/member/templates/member/organization_request_modal.html
@@ -4,7 +4,10 @@
   <div class="modal-organization-request" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="organization-{{status}}-{{organization.id}}-title">{{organization.name}}</h5>
+        <h5 class="modal-title" id="organization-{{status}}-{{organization.id}}-title">
+          {% if org.picture_url %}<img src="{org.picture_url}"/>{% endif %}
+          {{organization.name}}
+        </h5>
         <!-- <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button> -->

--- a/apps/member/templates/member/organization_request_modal.html
+++ b/apps/member/templates/member/organization_request_modal.html
@@ -1,20 +1,31 @@
+{% load static %}
 <!-- Modal -->
 <div class="modal" id="organization-{{status}}-{{organization.id}}" tabindex="-1" role="dialog" aria-labelledby="organization-{{status}}-{{organization.id}}-title" aria-hidden="true">
-  <div class="modal-dialog" role="document">
+  <div class="modal-organization-request" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="organization-{{status}}-{{organization.id}}-title">{{organization.name}}</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <!-- <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
-        </button>
+        </button> -->
       </div>
       <div class="modal-body">
         {% ifequal status 'current' %}
         <h2>Revoke Access</h2>
-        <p>Revoke from {{organization.name}} access to your medical files including mental health records?</p>
+        <div class="container-fluid">
+          <div class="row">
+            <div class="col-3 col-sm-2"><img src="{% static '/images/icons/alert.svg' %}" alt="" class="alert-item__image"/></div>
+            <div class="col-9 col-sm-10"><p>Revoke from {{organization.name}} access to your medical files including mental health records?</p></div>
+          </div>
+        </div>
         {% else %}
         <h2>{% ifequal status 'requested' %}Approve{% else %}Grant{% endifequal %} Access</h2>
-        <p>Allow {{organization.name}} to access your medical files including mental health records?</p>
+        <div class="container-fluid">
+          <div class="row">
+            <div class="col-3 col-sm-2"><img src="{% static '/images/icons/alert.svg' %}" alt="" class="alert-item__image"/></div>
+            <div class="col-9 col-sm-10"><p>Allow {{organization.name}} to access your medical files including mental health records?</p></div>
+          </div>
+        </div>
         {% endifequal %}
       </div>
       <div class="modal-footer">
@@ -32,8 +43,7 @@
           {% ifequal status 'available' %}
           <input type="submit" name="approve" class="btn btn-primary" value="Grant Access"></input>
           {% endifequal %}
-          &#x00a0;&#x00a0;
-          <a class="cancel" href="#" data-dismiss="modal">Cancel</a>
+          <button class="btn btn-secondary" data-dismiss="modal">Cancel</input>
         </form>
       </div>
     </div>

--- a/apps/member/templates/member/organization_request_modal.html
+++ b/apps/member/templates/member/organization_request_modal.html
@@ -5,7 +5,11 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="organization-{{status}}-{{organization.id}}-title">
-          {% if organization.picture_url %}<img src="{{organization.picture_url}}"/>{% endif %}
+          {% if organization.picture_url %}
+          <img src="{{organization.picture_url}}"/>
+          {% else %}
+          <img src="{% static '/images/icons/organization_default.png' %}"/>
+          {% endif %}
           {{organization.name}}
         </h5>
         <!-- <button type="button" class="close" data-dismiss="modal" aria-label="Close">

--- a/apps/member/templates/member/organization_request_modal.html
+++ b/apps/member/templates/member/organization_request_modal.html
@@ -1,11 +1,11 @@
 {% load static %}
 <!-- Modal -->
 <div class="modal" id="organization-{{status}}-{{organization.id}}" tabindex="-1" role="dialog" aria-labelledby="organization-{{status}}-{{organization.id}}-title" aria-hidden="true">
-  <div class="modal-organization-request" role="document">
+  <div class="organization-request__modal" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="organization-{{status}}-{{organization.id}}-title">
-          {% if org.picture_url %}<img src="{org.picture_url}"/>{% endif %}
+          {% if organization.picture_url %}<img src="{{organization.picture_url}}"/>{% endif %}
           {{organization.name}}
         </h5>
         <!-- <button type="button" class="close" data-dismiss="modal" aria-label="Close">

--- a/apps/member/templates/member/organization_request_modal.html
+++ b/apps/member/templates/member/organization_request_modal.html
@@ -1,0 +1,41 @@
+<!-- Modal -->
+<div class="modal" id="organization-{{status}}-{{organization.id}}" tabindex="-1" role="dialog" aria-labelledby="organization-{{status}}-{{organization.id}}-title" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="organization-{{status}}-{{organization.id}}-title">{{organization.name}}</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        {% ifequal status 'current' %}
+        <h2>Revoke Access</h2>
+        <p>Revoke from {{organization.name}} access to your medical files including mental health records?</p>
+        {% else %}
+        <h2>{% ifequal status 'requested' %}Approve{% else %}Grant{% endifequal %} Access</h2>
+        <p>Allow {{organization.name}} to access your medical files including mental health records?</p>
+        {% endifequal %}
+      </div>
+      <div class="modal-footer">
+        <form method="POST" action="{% url 'member:resource_request_response' %}?next={{request.path}}">
+          {% csrf_token %}
+          <input type="hidden" name="organization" value="{{organization.id}}"></input>
+          <input type="hidden" name="member" value="{{member.id}}"></input>
+          {% ifequal status 'current' %}
+          <input type="submit" name="revoke" class="btn btn-primary" value="Yes, Revoke"></input>
+          {% endifequal %}
+          {% ifequal status 'requested' %}
+          <input type="submit" name="approve" class="btn btn-primary" value="Yes, Approve"></input>
+          <input type="submit" name="deny" class="btn btn-secondary" value="No, Deny"></input>
+          {% endifequal %}
+          {% ifequal status 'available' %}
+          <input type="submit" name="approve" class="btn btn-primary" value="Grant Access"></input>
+          {% endifequal %}
+          &#x00a0;&#x00a0;
+          <a class="cancel" href="#" data-dismiss="modal">Cancel</a>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/member/templates/member/organizations.html
+++ b/apps/member/templates/member/organizations.html
@@ -21,7 +21,12 @@
                     <div class="col-6 col-sm-4 col-md-3">
                         <a class="current-organization" data-toggle="modal" data-target="#organization-current-{{org.id}}" href="#">
                             <div class="tile tile-flex__item tile-flex__item--add">
-                                <p>{{ org.name }}</p>
+                                <p>
+                                    {% if org.picture_url %}
+                                    <img src="{org.picture_url}"/><br/>
+                                    {% endif %}
+                                    {{ org.name }}
+                                </p>
                             </div>
                         </a>
                     </div>

--- a/apps/member/templates/member/organizations.html
+++ b/apps/member/templates/member/organizations.html
@@ -23,7 +23,9 @@
                             <div class="organization__tile">
                                 <div class="tile__action">&#x2715;</div>
                                 {% if organization.picture_url %}
-                                <img class="tile__logo" src="{{organization.picture_url}}"/>
+                                <img class="tile__logo" src="{{ organization.picture_url }}"/>
+                                {% else %}
+                                <img class="tile__logo" src="{% static '/images/icons/organization_default.png' %}"/>
                                 {% endif %}
                                 <p class="tile__label">{{ organization.name }}</p>
                             </div>
@@ -42,7 +44,9 @@
                             <div class="organization__tile">
                                 <div class="tile__action"><img src="{% static '/images/icons/add.png' %}" alt=""></div>
                                 {% if organization.picture_url %}
-                                <img class="tile__logo" src="{{organization.picture_url}}"/>
+                                <img class="tile__logo" src="{{ organization.picture_url }}"/>
+                                {% else %}
+                                <img class="tile__logo" src="{% static '/images/icons/organization_default.png' %}"/>
                                 {% endif %}
                                 <p class="tile__label">{{ organization.name }}</p>
                             </div>
@@ -61,7 +65,9 @@
                             <div class="organization__tile">
                                 <div class="tile__action"><img src="{% static '/images/icons/add.png' %}" alt=""></div>
                                 {% if organization.picture_url %}
-                                <img class="tile__logo" src="{{organization.picture_url}}"/>
+                                <img class="tile__logo" src="{{ organization.picture_url }}"/>
+                                {% else %}
+                                <img class="tile__logo" src="{% static '/images/icons/organization_default.png' %}"/>
                                 {% endif %}
                                 <p class="tile__label">{{ organization.name }}</p>
                             </div>

--- a/apps/member/templates/member/organizations.html
+++ b/apps/member/templates/member/organizations.html
@@ -17,52 +17,57 @@
             <div class="mt-5">
                 <h2>Current Organizations</h2>
                 <div class="row">
-                    {% for org in organizations.current %}
+                    {% for organization in organizations.current %}
                     <div class="col-6 col-sm-4 col-md-3">
-                        <a class="current-organization" data-toggle="modal" data-target="#organization-current-{{org.id}}" href="#">
-                            <div class="tile tile-flex__item tile-flex__item--add">
-                                <p>
-                                    {% if org.picture_url %}
-                                    <img src="{org.picture_url}"/><br/>
-                                    {% endif %}
-                                    {{ org.name }}
-                                </p>
+                        <a class="current-organization" data-toggle="modal" data-target="#organization-current-{{organization.id}}" href="#">
+                            <div class="organization__tile">
+                                <div class="tile__action">&#x2715;</div>
+                                {% if organization.picture_url %}
+                                <img class="tile__logo" src="{{organization.picture_url}}"/>
+                                {% endif %}
+                                <p class="tile__label">{{ organization.name }}</p>
                             </div>
                         </a>
                     </div>
-                    {% include "member/organization_request_modal.html" with member=member organization=org status="current" %}
+                    {% include "member/organization_request_modal.html" with member=member organization=organization status="current" %}
                     {% endfor %}
                 </div>
             </div>
             <div class="mt-5">
                 <h2>Requests Waiting</h2>
                 <div class="row">
-                    {% for org in organizations.requested %}
+                    {% for organization in organizations.requested %}
                     <div class="col-6 col-sm-4 col-md-3">
-                        <a class="requested-organization" data-toggle="modal" data-target="#organization-requested-{{org.id}}" href="#">
-                            <div class="tile tile-flex__item tile-flex__item--add">
-                                <img src="{% static '/images/icons/add.png' %}" alt="">
-                                <p>{{ org.name }}</p>
+                        <a class="requested-organization" data-toggle="modal" data-target="#organization-requested-{{organization.id}}" href="#">
+                            <div class="organization__tile">
+                                <div class="tile__action"><img src="{% static '/images/icons/add.png' %}" alt=""></div>
+                                {% if organization.picture_url %}
+                                <img class="tile__logo" src="{{organization.picture_url}}"/>
+                                {% endif %}
+                                <p class="tile__label">{{ organization.name }}</p>
                             </div>
                         </a>
                     </div>
-                    {% include "member/organization_request_modal.html" with member=member organization=org  status="requested" %}
+                    {% include "member/organization_request_modal.html" with member=member organization=organization  status="requested" %}
                     {% endfor %}
                 </div>
             </div>
             <div class="mt-5">
                 <h2>Other Organizations</h2>
                 <div class="row">
-                    {% for org in organizations.available %}
+                    {% for organization in organizations.available %}
                     <div class="col-6 col-sm-4 col-md-3">
-                        <a class="available-organization" data-toggle="modal" data-target="#organization-available-{{org.id}}" href="#">
-                            <div class="tile tile-flex__item tile-flex__item--add">
-                                <img src="{% static '/images/icons/add.png' %}" alt="">
-                                <p>{{ org.name }}</p>
+                        <a class="available-organization" data-toggle="modal" data-target="#organization-available-{{organization.id}}" href="#">
+                            <div class="organization__tile">
+                                <div class="tile__action"><img src="{% static '/images/icons/add.png' %}" alt=""></div>
+                                {% if organization.picture_url %}
+                                <img class="tile__logo" src="{{organization.picture_url}}"/>
+                                {% endif %}
+                                <p class="tile__label">{{ organization.name }}</p>
                             </div>
                         </a>
                     </div>
-                    {% include "member/organization_request_modal.html" with member=member organization=org status="available" %}
+                    {% include "member/organization_request_modal.html" with member=member organization=organization status="available" %}
                     {% endfor %}
                 </div>
             </div>

--- a/apps/member/templates/member/organizations.html
+++ b/apps/member/templates/member/organizations.html
@@ -1,0 +1,67 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block extra_head %}
+<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+{% endblock %}
+
+{% block content %}
+<div class="row mr-0 ml-0">
+    {% include "member_sidebar.html" with member=member %}
+    <div class="member-tabs col-lg-9 p-5">
+        <h2 class="page-title">Organizations</h2>
+        <hr/>
+        <div class="member-orgs">
+            <div class="mt-5">
+                <h2>Current Organizations</h2>
+                <div class="row">
+                    {% for org in organizations.current %}
+                    <div class="col-6 col-sm-4 col-md-3">
+                        <a class="current-organization" data-toggle="modal" data-target="#organization-current-{{org.id}}" href="#">
+                            <div class="tile tile-flex__item tile-flex__item--add">
+                                <p>{{ org.name }}</p>
+                            </div>
+                        </a>
+                    </div>
+                    {% include "member/organization_request_modal.html" with member=member organization=org status="current" %}
+                    {% endfor %}
+                </div>
+            </div>
+            <div class="mt-5">
+                <h2>Requests Waiting</h2>
+                <div class="row">
+                    {% for org in organizations.requested %}
+                    <div class="col-6 col-sm-4 col-md-3">
+                        <a class="requested-organization" data-toggle="modal" data-target="#organization-requested-{{org.id}}" href="#">
+                            <div class="tile tile-flex__item tile-flex__item--add">
+                                <img src="{% static '/images/icons/add.png' %}" alt="">
+                                <p>{{ org.name }}</p>
+                            </div>
+                        </a>
+                    </div>
+                    {% include "member/organization_request_modal.html" with member=member organization=org  status="requested" %}
+                    {% endfor %}
+                </div>
+            </div>
+            <div class="mt-5">
+                <h2>Other Organizations</h2>
+                <div class="row">
+                    {% for org in organizations.available %}
+                    <div class="col-6 col-sm-4 col-md-3">
+                        <a class="available-organization" data-toggle="modal" data-target="#organization-available-{{org.id}}" href="#">
+                            <div class="tile tile-flex__item tile-flex__item--add">
+                                <img src="{% static '/images/icons/add.png' %}" alt="">
+                                <p>{{ org.name }}</p>
+                            </div>
+                        </a>
+                    </div>
+                    {% include "member/organization_request_modal.html" with member=member organization=org status="available" %}
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock content %}

--- a/apps/member/templates/member_sidebar.html
+++ b/apps/member/templates/member_sidebar.html
@@ -1,15 +1,15 @@
 {% load static %}
 <div class="member-sidebar col-lg-3 pl-0 pb-5 pr-0">
     <div class="member-sidebar__image">
-        
-        
+
+
          {% if request.user.userprofile.picture_url %}
                       <img src="{{ member.user.userprofile.picture_url }}" alt="{{ member.user.first_name }} {{ member.user.last_name }}",  class="member-avatar">
                     {% else %}
                       <img src="{% static '/images/icons/avatar_default.png' %}" alt=">{{ member.user.first_name }} {{ member.user.last_name }}", c class="member-avatar">
                     {% endif %}
-        
-            
+
+
         <p class="member-avatar__overlay mb-0"><img src="/images/icons/star.png" alt="">ID Verified</p>
     </div>
     <div class="member-sidebar__nav">
@@ -32,7 +32,7 @@
                         <a href="{% url 'member:records' member.id 'list' %}" class="nav-link {% if url == 'data-sources' %}active{% endif %}" role="button">Medical Data</a>
                         <a href="#" data-rb-event-key="memberNotes" class="nav-link" role="button">Notes</a>
                         <a href="#" data-rb-event-key="memberLockbox" class="nav-link" role="button">Lockbox</a>
-                        <a href="#" data-rb-event-key="memberOrgs" class="nav-link" role="button">Organizations</a>
+                        <a href="{% url 'member:organizations' member.id %}" data-rb-event-key="memberOrgs" class="nav-link  {% if url == 'organizations' %}active{% endif %}" role="button">Organizations</a>
                     </div>
                 {% endif %}
             </div>

--- a/apps/member/urls.py
+++ b/apps/member/urls.py
@@ -2,9 +2,10 @@
 from django.conf.urls import url
 
 from .views import (
-    approve_resource_request, revoke_resource_request,
-    CreateMemberView, DashboardView, DataSourcesView, DeleteMemberView, RecordsView,
-    SummaryView, ProvidersView, UpdateMemberView
+    approve_resource_request, revoke_resource_request, resource_request_response,
+    CreateMemberView, DeleteMemberView, UpdateMemberView,
+    DashboardView, DataSourcesView, RecordsView, OrganizationsView,
+    SummaryView, ProvidersView,
 )
 
 # Copyright Videntity Systems Inc.
@@ -29,6 +30,9 @@ urlpatterns = [
     url(r'^(?P<pk>[0-9]+)/data-sources/(?P<resource_name>[\w]+)/(?P<record_type>[\w]+)/$',
         DataSourcesView.as_view(),
         name='data-sources'),
+    url(r'^(?P<pk>[0-9]+)/organizations/$',
+        OrganizationsView.as_view(),
+        name='organizations'),
     url(r'^new/$',
         CreateMemberView.as_view(),
         name='member-create'),
@@ -40,6 +44,9 @@ urlpatterns = [
         name='member-delete'),
     url(r'^$',
         DashboardView.as_view(), name='dashboard'),
+
+    # Member/Org ResourceRequests
+    url(r'^resource_request_response/$', resource_request_response, name='resource_request_response'),
     url(r'^approve_resource_request/(?P<pk>[0-9]+)/$',
         approve_resource_request,
         name='approve_resource_request'),

--- a/apps/member/views.py
+++ b/apps/member/views.py
@@ -12,8 +12,10 @@ from .constants import RECORDS
 from .models import Member
 from .utils import fetch_member_data, get_resource_data
 from apps.org.models import (
-    ResourceGrant, ResourceRequest, REQUEST_APPROVED, REQUEST_DENIED
+    Organization, ResourceGrant, ResourceRequest, RESOURCE_CHOICES,
+    REQUEST_REQUESTED, REQUEST_APPROVED, REQUEST_DENIED,
 )
+from .forms import ResourceRequestForm
 
 
 def get_id_token_payload(user):
@@ -226,6 +228,26 @@ class DataSourcesView(LoginRequiredMixin, SelfOrApprovedOrgMixin, UserPassesTest
         return context
 
 
+class OrganizationsView(LoginRequiredMixin, SelfOrApprovedOrgMixin, DetailView):
+    model = Member
+    template_name = "member/organizations.html"
+
+    def get_context_data(self, **kwargs):
+        """Add organizations data into the context."""
+        context = super().get_context_data(**kwargs)
+        orgs = Organization.objects.all().order_by('name')
+        resources = ResourceRequest.objects.filter(member=context['member'].user)
+        current = [r.organization for r in resources if r.status == REQUEST_APPROVED]
+        requested = [r.organization for r in resources if r.status == REQUEST_REQUESTED]
+        available = [org for org in orgs if org not in current and org not in requested]
+        context['organizations'] = {
+            'current': current,
+            'requested': requested,
+            'available': available,
+        }
+        return context
+
+
 class CreateMemberView(LoginRequiredMixin, CreateView):
     model = Member
     fields = ['user', 'birth_date', 'phone_number', 'address',
@@ -287,6 +309,7 @@ def approve_resource_request(request, pk):
     )
     resource_request.status = REQUEST_APPROVED
     resource_request.save()
+
     # The ResourceRequest is for this member, so create a ResourceGrant for it
     ResourceGrant.objects.create(
         organization=resource_request.organization,
@@ -294,28 +317,98 @@ def approve_resource_request(request, pk):
         resource_class_path=resource_request.resource_class_path,
         resource_request=resource_request
     )
-    return redirect(reverse('member:dashboard'))
+
+    if request.GET.get('next'):
+        return redirect(request.GET['next'])
+    else:
+        return redirect(reverse('member:dashboard'))
+
+
+@require_POST
+@login_required(login_url='home')
+def resource_request_response(request):
+    """
+    A member can directly create a ResourceGrant to an organization who has not requested it.
+    This requires having both the 'member' and the 'organization' ids in the POST data.
+    """
+    if request.POST.get('approve'):
+        status = REQUEST_APPROVED
+    elif request.POST.get('deny') or request.POST.get('revoke'):
+        status = REQUEST_DENIED
+    else:
+        status = None
+    form = ResourceRequestForm({
+        'user': request.user.id,
+        'status': status,
+        'resource_class_path': RESOURCE_CHOICES[0][0],
+        'member': request.POST.get('member'),
+        'organization': request.POST.get('organization'),
+    })
+    if form.is_valid():
+        resource_request = ResourceRequest.objects.filter(
+            member=form.cleaned_data['member'],
+            organization=form.cleaned_data['organization'],
+            resource_class_path=form.cleaned_data['resource_class_path'],
+        ).first()
+        if resource_request is None:
+            resource_request = ResourceRequest.objects.create(
+                member=form.cleaned_data['member'],
+                organization=form.cleaned_data['organization'],
+                resource_class_path=form.cleaned_data['resource_class_path'],
+                user=request.user,
+            )
+        resource_request.status = form.cleaned_data['status']
+        resource_request.save()
+
+        if resource_request.status == REQUEST_DENIED:
+            # delete any existing ResourceGrant objects associated with this request
+            ResourceGrant.objects.filter(
+                member=resource_request.member,
+                organization=resource_request.organization,
+                resource_class_path=resource_request.resource_class_path,
+                resource_request=resource_request).delete()
+        elif resource_request.status == REQUEST_APPROVED:
+            # make sure there is a ResourceGrant object associated with this ResourceRequest
+            ResourceGrant.objects.get_or_create(
+                member=resource_request.member,
+                organization=resource_request.organization,
+                resource_class_path=resource_request.resource_class_path,
+                resource_request=resource_request)
+    else:
+        # create an error message indicating the error that occurred.
+        pass
+
+    if request.GET.get('next'):
+        return redirect(request.GET['next'])
+    else:
+        return redirect(reverse('member:dashboard'))
 
 
 @require_POST
 @login_required(login_url='home')
 def revoke_resource_request(request, pk):
     """
-    A view for a member to revoke access to a resource (after an approved ResourceRequest).
+    A view for a member to revoke access to a resource 
+    (either before or after an approved ResourceRequest).
 
     Revoking a ResourceRequest means setting its status to 'Denied', and
-    deleting the related ResourceGrant.
+    deleting the related ResourceGrant, if any.
     """
     # Is the ResourceRequest for this member?
     resource_request = get_object_or_404(
         ResourceRequest.objects.filter(member=request.user),
         pk=pk
     )
+    
     # The ResourceRequest is for this member; set its status to REQUEST_DENIED.
     resource_request.status = REQUEST_DENIED
     resource_request.save()
-    # The ResourceRequest is for this member, so delete the relevant
-    # ResourceGrant
+    
+    # The ResourceRequest is for this member, so delete the relevant ResourceGrant, if any
     if getattr(resource_request, 'resourcegrant', None):
         resource_request.resourcegrant.delete()
-    return redirect(reverse('member:dashboard'))
+
+    if request.GET.get('next'):
+        return redirect(request.GET['next'])
+    else:
+        return redirect(reverse('member:dashboard'))

--- a/apps/member/views.py
+++ b/apps/member/views.py
@@ -283,9 +283,11 @@ class DashboardView(LoginRequiredMixin, TemplateView):
         # Get all of the ResourceRequests for access to the self.request.user's
         # resources
         resource_requests = ResourceRequest.objects.filter(
-            member=self.request.user
-        ).order_by('-updated')[:4]
-        organizations = self.request.user.member.organizations.all()[:4]
+            member=self.request.user).order_by('-updated')[:4]
+        organizations = [
+            resource_grant.organization
+            for resource_grant in ResourceGrant.objects.filter(member=self.request.user)
+        ][:4]
         kwargs.setdefault('resource_requests', resource_requests)
         kwargs.setdefault('organizations', organizations)
         id_token_payload = get_id_token_payload(self.request.user)

--- a/assets/sass/App.scss
+++ b/assets/sass/App.scss
@@ -30,6 +30,7 @@
 @import 'components/MemberTabs/MemberRecords/member-records';
 @import 'components/MemberTabs/MemberId/member-id';
 @import 'components/MemberTabs/MemberId/MedicalId/medical-id';
+@import 'components/MemberTabs/MemberOrgs/member-orgs';
 @import 'components/Sidebar/sidebar';
 @import 'components/Tile/tile';
 @import 'components/UserLink/user-link';

--- a/assets/sass/components/MemberTabs/MemberOrgs/_member-orgs.scss
+++ b/assets/sass/components/MemberTabs/MemberOrgs/_member-orgs.scss
@@ -1,7 +1,43 @@
-.member-orgs .modal a.cancel {
-    color: $blue;
-    border-bottom-color: rgba(0,0,0,0);
-    &:hover {
-        border-bottom-color: $blue;
+.modal-organization-request {
+    @extend .modal-dialog;
+    max-width: 600px;
+
+    a.cancel {
+        color: $blue;
+        border-bottom-color: rgba(0,0,0,0);
+        &:hover {
+            border-bottom-color: $blue;
+        }
     }
+
+    .btn-primary, .btn-secondary {
+        background-color: rgba(0,0,0,0);
+        border: 0;
+        color: $blue;
+    }
+
+    .modal-body {
+        padding: 1rem 4rem;
+        h2 {
+            justify-content: space-around;
+            margin-bottom: 1rem;
+        }
+    }
+
+    .modal-footer {
+        border-top: 0;
+    }
+
+    .modal-header > *,
+    .modal-body > *, 
+    .modal-footer > * {
+        margin: 0 auto;
+    }
+
+    .modal-title {
+        font-size: 1.5rem;
+        font-weight: 500;        
+        text-transform: none;
+    }
+
 }

--- a/assets/sass/components/MemberTabs/MemberOrgs/_member-orgs.scss
+++ b/assets/sass/components/MemberTabs/MemberOrgs/_member-orgs.scss
@@ -1,0 +1,7 @@
+.member-orgs .modal a.cancel {
+    color: $blue;
+    border-bottom-color: rgba(0,0,0,0);
+    &:hover {
+        border-bottom-color: $blue;
+    }
+}

--- a/assets/sass/components/MemberTabs/MemberOrgs/_member-orgs.scss
+++ b/assets/sass/components/MemberTabs/MemberOrgs/_member-orgs.scss
@@ -19,8 +19,8 @@
 
     .tile__logo {
         margin-top: 1rem;
-        max-height: 100px;
-        max-width: 100px;
+        height: 80px;
+        max-width: 80px;
         border: 1px solid $blue;
         border-radius: 50px;
     }

--- a/assets/sass/components/MemberTabs/MemberOrgs/_member-orgs.scss
+++ b/assets/sass/components/MemberTabs/MemberOrgs/_member-orgs.scss
@@ -1,4 +1,36 @@
-.modal-organization-request {
+.organization__tile {
+    @extend .tile;
+    @extend .tile-flex__item;
+
+    align-items: flex-end !important;
+    min-height: 200px;
+
+    .tile__action {
+        color: $blue;   /* for when it's text rather than an image */
+        font-size: 1.5rem;
+        line-height: 1.0;
+
+        position: absolute;
+        /*right: 1.5rem;*/
+        text-align: right;
+        top: 1rem;
+        width: calc(100% - 30px - 2em);
+    }
+
+    .tile__logo {
+        margin-top: 1rem;
+        max-height: 100px;
+        max-width: 100px;
+        border: 1px solid $blue;
+        border-radius: 50px;
+    }
+
+    .tile__label {
+        margin-top: 0.5rem;
+    }
+}
+
+.organization-request__modal {
     @extend .modal-dialog;
     max-width: 600px;
 
@@ -38,6 +70,13 @@
         font-size: 1.5rem;
         font-weight: 500;        
         text-transform: none;
-    }
 
+        img {
+            max-height: 1.5em;
+            border: 1px solid $blue;
+            border-radius: 0.75em;
+            margin-right: 0.5em;
+        }
+    }
 }
+

--- a/assets/sass/components/MemberTabs/_member_dashboard.scss
+++ b/assets/sass/components/MemberTabs/_member_dashboard.scss
@@ -32,8 +32,8 @@
       display: flex;
       padding: 1rem;
       img.alert-item__image {
-        width: 80px;
         height: 80px;
+        max-width: 80px;
       }
       .title {
         color: $blue;
@@ -53,8 +53,8 @@
       align-items: center;
       padding: 1rem 0;
       .alert-item__image {
-        width: 100px;
         height: 100px;
+        max-width: 100px;
       }
       .profile-text {
         padding-left: 1rem;

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[flake8]
+max-line-length = 100
+include = apps,lib,smh_app
+exclude = migrations
+ignore = 
+	E121, 	# continuation line under-indented for hanging indent
+	E126,   # continuation line over-indented for hanging indent
+	E241,	# multiple spaces after ','
+	W291,   # trailing whitespace
+	W293,	# blank line contains whitespace
+	W391,   # blank line at end of file
+	W503,	# line break occurred before a binary operator
+	W504,	# line break occurred after a binary operator

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,9 @@
             work correctly both with client-side routing and a non-root public URL.
             Learn how to configure a non-root public URL by running `npm run build`.
         -->
-        <title>Share My Health</title>
+        <title>{% block page_title %}Share My Health{% endblock %}</title>
+
+        {% block extra_head %}{% endblock %}
     </head>
 
     <body>


### PR DESCRIPTION
This PR creates the Member organizations page, and the summary thereof on the Member dashboard with an edit link.

There's a quad-state of organization states represented by the ResourceRequest model: Requested, Approved, Denied, Available. On the org page, This is represented by a tri-state: Approved = Current, Requsted = Waiting, leaving both Denied and no ResourceRequest = Available. That way, if a member denies access and then later wants to add that organization, they can. 

We're now using bootstrap modals via popper.js. Bootstrap JS requires jquery as well. For now, I just pulled these into this page via CDN rather than adding them to the App.js — the total download is a lot smaller this way, at least for my crude front-end packaging skills. Bootstrap modals are awesome.

There are not yet any unit tests — those are coming. This way, we can go ahead and acceptance test these on staging (app.sharemy.health) ahead of tomorrow's demo.