### PR TITLE
make parse_timestamp always return a timezone-aware datetime

### DIFF
--- a/apps/data/util.py
+++ b/apps/data/util.py
@@ -1,15 +1,24 @@
 from datetime import datetime
 
 import dateparser
+from django.conf import settings
 
 
 def parse_timestamp(timestamp):
-    """parse a timestamp string, return a datetime"""
+    """parse a timestamp string, return a timezone-aware datetime, 
+    in the timezone of settings.TIME_ZONE
+    """
     if timestamp is not None:
         try:
             # fast but fragile
             dt = datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S%z')
         except ValueError:
             # slow but reliable
-            dt = dateparser.parse(timestamp)
+            dt = dateparser.parse(
+                timestamp,
+                settings={
+                    'RETURN_AS_TIMEZONE_AWARE': True,
+                    'TIMEZONE': settings.TIME_ZONE,
+                },
+            )
         return dt

--- a/apps/member/views.py
+++ b/apps/member/views.py
@@ -184,7 +184,10 @@ class RecordsView(LoginRequiredMixin, SelfOrApprovedOrgMixin, TemplateView):
                 diagnoses.append(diagnosis)
 
             # sort diagnoses in order of date descending
-            diagnoses.sort(key=lambda d: d['Date'] or datetime(1, 1, 1), reverse=True)
+            diagnoses.sort(
+                key=lambda d: d['Date'] or datetime(1, 1, 1, tzinfo=timezone.utc),
+                reverse=True,
+            )
 
             context.setdefault('title', 'Diagnoses')
             context.setdefault('headers', headers)
@@ -213,7 +216,10 @@ class RecordsView(LoginRequiredMixin, SelfOrApprovedOrgMixin, TemplateView):
                 lab_results.append(lab)
 
             # sort lab_results in order of date descending
-            lab_results.sort(key=lambda d: d['Date'] or datetime(1, 1, 1), reverse=True)
+            lab_results.sort(
+                key=lambda d: d['Date'] or datetime(1, 1, 1, tzinfo=timezone.utc),
+                reverse=True,
+            )
 
             context.setdefault('title', 'Lab Results')
             context.setdefault('headers', headers)
@@ -243,7 +249,10 @@ class RecordsView(LoginRequiredMixin, SelfOrApprovedOrgMixin, TemplateView):
                 procedures.append(procedure)
 
             # sort procedures in order of date descending
-            procedures.sort(key=lambda d: d['Date'] or datetime(1, 1, 1), reverse=True)
+            procedures.sort(
+                key=lambda d: d['Date'] or datetime(1, 1, 1, tzinfo=timezone.utc),
+                reverse=True,
+            )
 
             context.setdefault('title', 'Procedures')
             context.setdefault('headers', headers)
@@ -264,7 +273,7 @@ class RecordsView(LoginRequiredMixin, SelfOrApprovedOrgMixin, TemplateView):
                     ],
                     key=lambda np: np[1]['statements']
                     and np[1]['statements'][0].effectivePeriod.start
-                    or datetime(1, 1, 1),
+                    or datetime(1, 1, 1, tzinfo=timezone.utc),
                     reverse=True,
                 )
             ]
@@ -284,7 +293,8 @@ class RecordsView(LoginRequiredMixin, SelfOrApprovedOrgMixin, TemplateView):
                     ),
                 }
                 record['links'] = {
-                    'Medication': f"/member/{context['member'].id}/modal/prescription/{prescription['medication'].id}"
+                    'Medication': f"/member/{context['member'].id}"
+                    + "/modal/prescription/{prescription['medication'].id}"
                 }
                 all_records.append(record)
 

--- a/apps/org/tests/test_views.py
+++ b/apps/org/tests/test_views.py
@@ -2027,9 +2027,7 @@ class OrgSearchMembersAPITestCase(SMHAppTestMixin, TestCase):
         member = UserFactory()
 
         # organization.members.add(member)
-        ResourceGrant.objects.create(
-            organization=organization, member=member
-        )
+        ResourceGrant.objects.create(organization=organization, member=member)
 
         self.client.force_login(agent)
         response = self.client.get(reverse(self.url_name))


### PR DESCRIPTION
and create timezone-aware datetimes in the medical data pages.