### PR TITLE
Use django-session-security to manage session timeout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ httmock==1.3.0
 
 boto3==1.9.130
 datamodels==0.5.1
+django-session-security==2.6.5

--- a/smh_app/settings.py
+++ b/smh_app/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'session_security',
     'localflavor',
     'phonenumber_field',
     'apps.common',
@@ -67,6 +68,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'session_security.middleware.SessionSecurityMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
@@ -360,7 +362,9 @@ PHONENUMBER_DB_FORMAT = 'E164'
 PHONENUMBER_DEFAULT_FORMAT = 'NATIONAL'
 
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
-SESSION_COOKIE_AGE = int(env('SESSION_COOKIE_AGE', int(10 * 60)))
 
 # This setting fixes a bug with OAuth on Safari
 SESSION_COOKIE_SAMESITE = None
+
+# Using django-session-security to manage session timeout
+SESSION_SECURITY_EXPIRE_AFTER = 30 * 60  # 30 min inactivity

--- a/smh_app/urls.py
+++ b/smh_app/urls.py
@@ -48,4 +48,5 @@ urlpatterns = [
     path(r'user/', include('apps.users.urls')),
     path('social-auth/', include('social_django.urls', namespace='social')),
     path('admin/', admin.site.urls),
+    path(r'session_security/', include('session_security.urls')),
 ]

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,12 @@
 
         {% include "include/footer.html" %}
 
+        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+
+        <script src="{% static 'App.js' %}"></script>
+
+        {% include 'session_security/all.html' %}
+
         {% block ExtraJSFoot %}{% endblock %}
 
     </body>

--- a/templates/include/footer.html
+++ b/templates/include/footer.html
@@ -23,13 +23,3 @@
             {% endif %}
         </div>
  </div>
-
-<!-- JavaScript auto-logout -->
-{% if user.is_authenticated %}
-    <script type="text/javascript">
-        var time = 1000 * {% firstof settings.SESSION_COOKIE_AGE 1800 %}; // default 30 minutes
-        var theTimer = setTimeout("document.location.href='/logout'",time);
-    </script>
-{% endif %}
-
- <script src="{% static 'App.js' %}"></script>

--- a/templates/modal_base.html
+++ b/templates/modal_base.html
@@ -10,6 +10,7 @@
     {% block content %}
     {% endblock content %}
 </div>
+
 <script>
     document.addEventListener("DOMContentLoaded", function() {
         // close the modal
@@ -23,5 +24,6 @@
         }
     });
 </script>
+{% include 'session_security/all.html' %}
 </body>
 </html>


### PR DESCRIPTION
The session-timeout now happens after 30 minutes idle rather than 30 minutes on the clock. 

django-session-security doesn't provide a setting to have different timeouts based on different user classes. 

Do we really need to have different timeouts for CBO vs regular users? If so, I can spend the time on it – but want to make sure it's worth the investment.