### PR TITLE
Fix admin UserProfile delete

### DIFF
--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -71,6 +71,8 @@ class UserProfile(models.Model):
     def __str__(self):
         return self.user.username
 
+    __html__ = __str__
+
     def __getattr__(self, key):
         """Provide direct read access to attributes of the id_token."""
         # self.__getattribute__(key) failed, so check self.id_token_payload


### PR DESCRIPTION
Define UserProfile.__html__ method as = UserProfile.__str__ so the admin dashboard can work.

Ridiculously small fix. Why does Django need __html__ on the model and then not define it by default?