### PR TITLE
remove reference to assets/dist in STATICFILES_DIRS

### DIFF
--- a/smh_app/settings.py
+++ b/smh_app/settings.py
@@ -315,7 +315,6 @@ MEMBER_DATA_RECORD_TYPE_MAPPING = {
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'sitestatic'),
-    os.path.join(BASE_DIR, 'assets/dist'),
 ]
 
 STATIC_URL = '/static/'


### PR DESCRIPTION
pre-compiled App.js and App.css no longer need the assets/dist folder.
Removing this from STATICFILES_DIRS avoids a crash in collectstatic